### PR TITLE
Возможность указания пути к SwiftyVKState

### DIFF
--- a/Library/Sources/Common/VK.swift
+++ b/Library/Sources/Common/VK.swift
@@ -2,12 +2,14 @@ import Foundation
 
 /// SwiftyVK entry point
 public final class VK {
-    public static func setUp(appId: String, delegate: SwiftyVKDelegate, bundleName: String? = nil, configPath: String? = nil) {
+    public static func setUp(appId: String, delegate: SwiftyVKDelegate,
+							 bundleName: String? = nil, configPath: String? = nil) {
         guard dependencies == nil else {
             return
         }
         
-        dependencies = dependenciesType.init(appId: appId, delegate: delegate, bundleName: bundleName, configPath: configPath)
+        dependencies = dependenciesType.init(appId: appId, delegate: delegate,
+											 bundleName: bundleName, configPath: configPath)
     }
     
     /// Returns SwiftyVK user sessions

--- a/Library/Sources/Common/VK.swift
+++ b/Library/Sources/Common/VK.swift
@@ -2,14 +2,20 @@ import Foundation
 
 /// SwiftyVK entry point
 public final class VK {
-    public static func setUp(appId: String, delegate: SwiftyVKDelegate,
-							 bundleName: String? = nil, configPath: String? = nil) {
+    public static func setUp(
+            appId: String,
+            delegate: SwiftyVKDelegate,
+            bundleName: String? = nil,
+            configPath: String? = nil) {
         guard dependencies == nil else {
             return
         }
         
-        dependencies = dependenciesType.init(appId: appId, delegate: delegate,
-											 bundleName: bundleName, configPath: configPath)
+        dependencies = dependenciesType.init(
+            appId: appId,
+            delegate: delegate,
+            bundleName: bundleName,
+            configPath: configPath)
     }
     
     /// Returns SwiftyVK user sessions

--- a/Library/Sources/Common/VK.swift
+++ b/Library/Sources/Common/VK.swift
@@ -2,12 +2,12 @@ import Foundation
 
 /// SwiftyVK entry point
 public final class VK {
-    public static func setUp(appId: String, delegate: SwiftyVKDelegate) {
+    public static func setUp(appId: String, delegate: SwiftyVKDelegate, bundleName: String? = nil, configPath: String? = nil) {
         guard dependencies == nil else {
             return
         }
         
-        dependencies = dependenciesType.init(appId: appId, delegate: delegate)
+        dependencies = dependenciesType.init(appId: appId, delegate: delegate, bundleName: bundleName, configPath: configPath)
     }
     
     /// Returns SwiftyVK user sessions

--- a/Library/Sources/Dependecies/Dependencies.swift
+++ b/Library/Sources/Dependecies/Dependencies.swift
@@ -17,6 +17,12 @@ protocol DependenciesHolder: SessionsHolderHolder, AuthorizatorHolder {
     init(appId: String, delegate: SwiftyVKDelegate?, bundleName: String?, configPath: String?)
 }
 
+extension DependenciesHolder {
+    init(appId: String, delegate: SwiftyVKDelegate?) {
+        self.init(appId: appId, delegate: delegate, bundleName: nil, configPath: nil)
+    }
+}
+
 protocol SessionsHolderHolder: class {
     var sessionsHolder: SessionsHolder & SessionSaver { get }
 }

--- a/Library/Sources/Dependecies/Dependencies.swift
+++ b/Library/Sources/Dependecies/Dependencies.swift
@@ -14,7 +14,7 @@ protocol Dependencies:
     ShareControllerMaker { }
 
 protocol DependenciesHolder: SessionsHolderHolder, AuthorizatorHolder {
-    init(appId: String, delegate: SwiftyVKDelegate?)
+    init(appId: String, delegate: SwiftyVKDelegate?, bundleName: String?, configPath: String?)
 }
 
 protocol SessionsHolderHolder: class {

--- a/Library/Sources/Dependecies/DependenciesImpl.swift
+++ b/Library/Sources/Dependecies/DependenciesImpl.swift
@@ -10,6 +10,8 @@ final class DependenciesImpl: Dependencies {
     
     private let appId: String
     private weak var delegate: SwiftyVKDelegate?
+	private let name: String?
+	private let configPath: String
     
     private let longPollTaskTimeout: TimeInterval = 30
     private let uiSyncQueue = DispatchQueue(label: "SwiftyVK.uiSyncQueue")
@@ -48,9 +50,11 @@ final class DependenciesImpl: Dependencies {
         )
     }()
     
-    init(appId: String, delegate: SwiftyVKDelegate?) {
+	init(appId: String, delegate: SwiftyVKDelegate?, bundleName: String? = nil, configPath: String? = nil) {
         self.appId = appId
         self.delegate = delegate
+		self.name = bundleName
+		self.configPath = configPath ?? "SwiftyVKState"
     }
     
     lazy var sessionsHolder: SessionsHolder & SessionSaver = {
@@ -74,7 +78,7 @@ final class DependenciesImpl: Dependencies {
         SessionsStorageImpl(
             fileManager: FileManager(),
             bundleName: self.bundleName,
-            configName: "SwiftyVKState"
+            configName: self.configPath
         )
     }()
     
@@ -83,7 +87,7 @@ final class DependenciesImpl: Dependencies {
     }()
     
     private lazy var bundleName: String = {
-        Bundle.main.infoDictionary?[String(kCFBundleNameKey)] as? String ?? "SwiftyVK"
+		name ?? Bundle.main.infoDictionary?[String(kCFBundleNameKey)] as? String ?? "SwiftyVK"
     }()
     
     func session(id: String, config: SessionConfig, sessionSaver: SessionSaver) -> Session {
@@ -129,7 +133,7 @@ final class DependenciesImpl: Dependencies {
         #endif
         
         let tokenStorge = TokenStorageImpl(serviceKey: self.bundleName + "_Token")
-        
+		
         let vkAppProxy = VKAppProxyImpl(
             appId: self.appId,
             urlOpener: urlOpener,

--- a/Library/Sources/Dependecies/DependenciesImpl.swift
+++ b/Library/Sources/Dependecies/DependenciesImpl.swift
@@ -10,8 +10,8 @@ final class DependenciesImpl: Dependencies {
     
     private let appId: String
     private weak var delegate: SwiftyVKDelegate?
-	private let name: String?
-	private let configPath: String
+    private let customBundleName: String?
+    private let customConfigPath: String?
     
     private let longPollTaskTimeout: TimeInterval = 30
     private let uiSyncQueue = DispatchQueue(label: "SwiftyVK.uiSyncQueue")
@@ -50,11 +50,11 @@ final class DependenciesImpl: Dependencies {
         )
     }()
     
-	init(appId: String, delegate: SwiftyVKDelegate?, bundleName: String? = nil, configPath: String? = nil) {
+    init(appId: String, delegate: SwiftyVKDelegate?, bundleName: String?, configPath: String?) {
         self.appId = appId
         self.delegate = delegate
-		self.name = bundleName
-		self.configPath = configPath ?? "SwiftyVKState"
+        self.customBundleName = bundleName
+        self.customConfigPath = configPath
     }
     
     lazy var sessionsHolder: SessionsHolder & SessionSaver = {
@@ -78,7 +78,7 @@ final class DependenciesImpl: Dependencies {
         SessionsStorageImpl(
             fileManager: FileManager(),
             bundleName: self.bundleName,
-            configName: self.configPath
+            configName: self.customConfigPath ?? "SwiftyVKState"
         )
     }()
     
@@ -87,7 +87,7 @@ final class DependenciesImpl: Dependencies {
     }()
     
     private lazy var bundleName: String = {
-		name ?? Bundle.main.infoDictionary?[String(kCFBundleNameKey)] as? String ?? "SwiftyVK"
+        customBundleName ?? Bundle.main.infoDictionary?[String(kCFBundleNameKey)] as? String ?? "SwiftyVK"
     }()
     
     func session(id: String, config: SessionConfig, sessionSaver: SessionSaver) -> Session {
@@ -179,7 +179,7 @@ final class DependenciesImpl: Dependencies {
         
         #if os(iOS)
             controller = storyboard().instantiateViewController(
-                withIdentifier: name
+                withIdentifier: customBundleName
                 )
         #elseif os(macOS)
             controller = storyboard().instantiateController(
@@ -209,7 +209,7 @@ final class DependenciesImpl: Dependencies {
         #if os(macOS)
             let name = NSStoryboard.Name(rawValue: Resources.withSuffix("Storyboard"))
         #elseif os(iOS)
-            let name = Resources.withSuffix("Storyboard")
+            let customBundleName = Resources.withSuffix("Storyboard")
         #endif
         
         return VKStoryboard(

--- a/Library/Sources/Sessions/Management/AppLifecycleProvider.swift
+++ b/Library/Sources/Sessions/Management/AppLifecycleProvider.swift
@@ -19,28 +19,28 @@ final class IOSAppLifecycleProvider: AppLifecycleProvider {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleDidBecomeActive),
-            name: NSNotification.Name.UIApplicationDidBecomeActive,
+            customBundleName: NSNotification.Name.UIApplicationDidBecomeActive,
             object: application
         )
         
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleWillResignActive),
-            name: NSNotification.Name.UIApplicationWillResignActive,
+            customBundleName: NSNotification.Name.UIApplicationWillResignActive,
             object: application
         )
         
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleDidEnterBackground),
-            name: NSNotification.Name.UIApplicationDidEnterBackground,
+            customBundleName: NSNotification.Name.UIApplicationDidEnterBackground,
             object: application
         )
         
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleWillEnterForeground),
-            name: NSNotification.Name.UIApplicationWillEnterForeground,
+            customBundleName: NSNotification.Name.UIApplicationWillEnterForeground,
             object: application
         )
     }

--- a/Library/Sources/Sessions/Management/SessionsStorage.swift
+++ b/Library/Sources/Sessions/Management/SessionsStorage.swift
@@ -41,7 +41,7 @@ final class SessionsStorageImpl: SessionsStorage {
     
     func configurationUrl() throws -> URL {
 		if configName.starts(with: "/") {
-            return URL.init(fileURLWithPath: configName)
+            return URL(fileURLWithPath: configName)
         }
         return try fileManager.url(
             for: .applicationSupportDirectory,

--- a/Library/Sources/Sessions/Management/SessionsStorage.swift
+++ b/Library/Sources/Sessions/Management/SessionsStorage.swift
@@ -40,7 +40,7 @@ final class SessionsStorageImpl: SessionsStorage {
     }
     
     func configurationUrl() throws -> URL {
-		if configName.starts(with: "/") {
+        if configName.starts(with: "/") {
             return URL(fileURLWithPath: configName)
         }
         return try fileManager.url(

--- a/Library/Sources/Sessions/Management/SessionsStorage.swift
+++ b/Library/Sources/Sessions/Management/SessionsStorage.swift
@@ -40,6 +40,9 @@ final class SessionsStorageImpl: SessionsStorage {
     }
     
     func configurationUrl() throws -> URL {
+		if configName.starts(with: "/") {
+            return URL.init(fileURLWithPath: configName)
+        }
         return try fileManager.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask,

--- a/Library/Tests/Doubles/DependencyFactoryMock.swift
+++ b/Library/Tests/Doubles/DependencyFactoryMock.swift
@@ -5,7 +5,7 @@ final class DependenciesHolderMock: DependenciesHolder {
     
     var onInit: ((String, SwiftyVKDelegate?) -> ())?
     
-    init(appId: String, delegate: SwiftyVKDelegate?) {
+    init(appId: String, delegate: SwiftyVKDelegate?, bundleName: String? = nil, configPath: String? = nil) {
         onInit?(appId, delegate)
     }
     

--- a/Library/Tests/Doubles/DependencyFactoryMock.swift
+++ b/Library/Tests/Doubles/DependencyFactoryMock.swift
@@ -5,7 +5,7 @@ final class DependenciesHolderMock: DependenciesHolder {
     
     var onInit: ((String, SwiftyVKDelegate?) -> ())?
     
-    init(appId: String, delegate: SwiftyVKDelegate?, bundleName: String? = nil, configPath: String? = nil) {
+    init(appId: String, delegate: SwiftyVKDelegate?, bundleName: String?, configPath: String?) {
         onInit?(appId, delegate)
     }
     

--- a/Library/Tests/SessionsStorageTests.swift
+++ b/Library/Tests/SessionsStorageTests.swift
@@ -24,8 +24,41 @@ final class SessionStorageTests: XCTestCase {
             if fileManager.fileExists(atPath: fileUrl.path) {
                 try fileManager.removeItem(at: fileUrl)
             }
-        } catch let error {
+        }
+        catch let error {
             XCTFail("Config not removed with error: \(error)")
+        }
+    }
+    
+    func test_configPath_name() {
+        let storage = SessionsStorageImpl(
+            fileManager: FileManager(),
+            bundleName: "SwiftyVKTests",
+            configName: "SwiftyVKConfig")
+        do {
+            let configUrl = try storage.configurationUrl()
+            XCTAssertEqual(configUrl.lastPathComponent, "SwiftyVKConfig.plist")
+            XCTAssertEqual(configUrl.pathComponents.dropLast().last, "SwiftyVKTests")
+            XCTAssertEqual(configUrl.pathComponents.dropLast().dropLast().last, "Application Support")
+        }
+        catch let error {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func test_configPath_absolute() {
+        do {
+            let configPath = try FileManager.default.url(
+                for: FileManager.SearchPathDirectory.trashDirectory,
+                in: FileManager.SearchPathDomainMask.allDomainsMask,
+                appropriateFor: nil,
+                create: false)
+                .appendingPathComponent("state.xml")
+            let storage = SessionsStorageImpl(fileManager: FileManager(), bundleName: "", configName: configPath.path)
+            XCTAssertEqual(try storage.configurationUrl().path, configPath.path)
+        }
+        catch let error {
+            XCTFail("Unexpected error: \(error)")
         }
     }
     
@@ -39,7 +72,8 @@ final class SessionStorageTests: XCTestCase {
             let restoredSessions = try storage.restore()
             // Then
             XCTAssertEqual(session.id, restoredSessions.first?.id)
-        } catch let error {
+        }
+        catch let error {
             XCTFail("Unexpected error: \(error)")
         }
     }
@@ -52,7 +86,8 @@ final class SessionStorageTests: XCTestCase {
             _ = try storage.restore()
             // Then
             XCTFail("Expression should throw error")
-        } catch let error {
+        }
+        catch let error {
             XCTAssertEqual((error as NSError).domain, NSCocoaErrorDomain)
             XCTAssertEqual((error as NSError).code, 260)
         }


### PR DESCRIPTION
У меня есть основное приложение, в котором выполняется авторизация, и расширения "Поделиться", которые используют полученный токен. Чтобы они могли его найти, нужна возможность указания пути к файлу сессии, который не зависит от bundleID.

Пример использования (требуется entitlement com.apple.security.application-groups):
```swift
let configPath = (FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "P5ZFLGLAFT.group.com.PaztalomTechnologiez.ShareToVK")!.appendingPathComponent("Library").appendingPathComponent("Preferences").appendingPathComponent("SwiftyVKState.plist"))
VK.setUp(appId: "5474771", delegate: self, bundleName: "com.PaztalomTechnologiez.ShareExtensionForVK", configPath: configPath.path)
```