### PR TITLE
add releasing

### DIFF
--- a/Library/Sources/Common/VK.swift
+++ b/Library/Sources/Common/VK.swift
@@ -27,6 +27,7 @@ public final class VK {
         return sessionsHolder
     }
     
+    /// Free up all resources
     public static func release() {
         dependencies = nil
     }

--- a/Library/Sources/Common/VK.swift
+++ b/Library/Sources/Common/VK.swift
@@ -27,7 +27,9 @@ public final class VK {
         return sessionsHolder
     }
     
-    /// Free up all resources
+    /// Free up all SwiftyVK's resources and release memory
+    /// Call it only if you won't interact with the library anymore
+    /// If you'll need to work with the library again after calling this method, you should call setUp
     public static func release() {
         dependencies = nil
     }

--- a/Library/Sources/Common/VK.swift
+++ b/Library/Sources/Common/VK.swift
@@ -27,7 +27,7 @@ public final class VK {
         return sessionsHolder
     }
     
-    public static func releaseDependencies() {
+    public static func release() {
         dependencies = nil
     }
 

--- a/Library/Sources/Common/VK.swift
+++ b/Library/Sources/Common/VK.swift
@@ -26,6 +26,10 @@ public final class VK {
         
         return sessionsHolder
     }
+    
+    public static func releaseDependencies() {
+        dependencies = nil
+    }
 
     static var dependenciesType: DependenciesHolder.Type = DependenciesImpl.self
     private static var dependencies: DependenciesHolder?

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ class VKDelegateExample: SwiftyVKDelegate {
 VK.setUp(appId: String, delegate: SwiftyVKDelegate)
 ```
 
+### Releasing
+
+in order to free up resources that holds SwiftyVK use:
+
+```swift
+VK.release()
+```
+note you must setup it again for further using
+
+
 ## **Authorization**
 
 SwiftyVK provides several ways to authorize user. Choose the one that's more suitable for you.


### PR DESCRIPTION
Возникла ситуация: открывается модуль авторизации, в котором есть сервис для авторизации через ВК, где вызывается VK.setup. Если закрыть модуль авторизациию, то делегат деаллоцируется, - соответственно при повторном открытии модуля авторизации VK.sessions.default.logIn сразу выкидывает ошибку vkDelegateNotFound

Добавил функцию releaseDependencies и вызвал ее в deinit моего делегата - описанная выше ситуация исправлена. 
