### PR TITLE
Authorization Code Flow

### DIFF
--- a/Example/APIWorker.swift
+++ b/Example/APIWorker.swift
@@ -22,6 +22,8 @@ final class APIWorker {
             validation()
         case 8:
             share()
+        case 9:
+            authorizeCode()
         default:
             print("Unrecognized action!")
         }
@@ -34,6 +36,17 @@ final class APIWorker {
             },
             onError: { error in
                 print("SwiftyVK: authorize failed with", error)
+            }
+        )
+    }
+    
+    class func authorizeCode() {
+        VK.sessions.default.logInCode(
+            onSuccess: { info in
+                print("SwiftyVK: code: success authorize with", info)
+            },
+            onError: { error in
+                print("SwiftyVK: code: authorize failed with", error)
             }
         )
     }

--- a/Example/iOS/Base.lproj/Main.storyboard
+++ b/Example/iOS/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QE8-nE-Wxk">
-                                <rect key="frame" x="100" y="189.5" width="175" height="288"/>
+                                <rect key="frame" x="100" y="171.5" width="175" height="324"/>
                                 <subviews>
                                     <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yix-Dv-nXN">
                                         <rect key="frame" x="0.0" y="0.0" width="175" height="36"/>
@@ -32,8 +30,16 @@
                                             <action selector="buttonDown:" destination="BYZ-38-t0r" eventType="touchUpInside" id="j8a-qz-N5o"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2mB-oy-1Ya">
+                                    <button opaque="NO" tag="9" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DjA-vr-Mdf">
                                         <rect key="frame" x="0.0" y="36" width="175" height="36"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <state key="normal" title="Log in (code)"/>
+                                        <connections>
+                                            <action selector="buttonDown:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RjG-Tr-qN0"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2mB-oy-1Ya">
+                                        <rect key="frame" x="0.0" y="72" width="175" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="Log out"/>
                                         <connections>
@@ -41,7 +47,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Ts-fo-28A">
-                                        <rect key="frame" x="0.0" y="72" width="175" height="36"/>
+                                        <rect key="frame" x="0.0" y="108" width="175" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="Capthca"/>
                                         <connections>
@@ -49,7 +55,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r0F-8Z-tVI">
-                                        <rect key="frame" x="0.0" y="108" width="175" height="36"/>
+                                        <rect key="frame" x="0.0" y="144" width="175" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="Validation"/>
                                         <connections>
@@ -57,7 +63,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="8" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s3g-RA-kyd">
-                                        <rect key="frame" x="0.0" y="144" width="175" height="36"/>
+                                        <rect key="frame" x="0.0" y="180" width="175" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="Share"/>
                                         <connections>
@@ -65,7 +71,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Kh-8o-KUN">
-                                        <rect key="frame" x="0.0" y="180" width="175" height="36"/>
+                                        <rect key="frame" x="0.0" y="216" width="175" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="users.get"/>
                                         <connections>
@@ -73,7 +79,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vli-Na-e0N">
-                                        <rect key="frame" x="0.0" y="216" width="175" height="36"/>
+                                        <rect key="frame" x="0.0" y="252" width="175" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="friends.get"/>
                                         <connections>
@@ -81,7 +87,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kUH-eh-OBo">
-                                        <rect key="frame" x="0.0" y="252" width="175" height="36"/>
+                                        <rect key="frame" x="0.0" y="288" width="175" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="upload photo to wall"/>
                                         <connections>

--- a/Library/Sources/Common/SwiftyVKDelegate.swift
+++ b/Library/Sources/Common/SwiftyVKDelegate.swift
@@ -30,6 +30,11 @@ public protocol SwiftyVKSessionDelegate: class {
     /// Use this point to cancel all SwiftyVK requests and remove session data
     /// parameter sessionId: SwiftyVK session identifier
     func vkTokenRemoved(for sessionId: String)
+    
+    /// Called when user grant access and SwiftyVK gets new code
+    /// Can be used for authorize user on your server side
+    /// parameter sessionId: SwiftyVK session identifier
+    func vkCodeCreated(for sessionId: String, info: [String: String])
 }
 
 extension SwiftyVKSessionDelegate {
@@ -40,4 +45,5 @@ extension SwiftyVKSessionDelegate {
     public func vkTokenCreated(for sessionId: String, info: [String: String]) {}
     public func vkTokenUpdated(for sessionId: String, info: [String: String]) {}
     public func vkTokenRemoved(for sessionId: String) {}
+    public func vkCodeCreated(for sessionId: String, info: [String: String]) {}
 }

--- a/Library/Sources/Dependecies/Dependencies.swift
+++ b/Library/Sources/Dependecies/Dependencies.swift
@@ -6,6 +6,7 @@ protocol Dependencies:
     TaskMaker,
     AttemptMaker,
     TokenMaker,
+    CodeMaker,
     WebControllerMaker,
     CaptchaControllerMaker,
     LongPollTaskMaker,
@@ -45,6 +46,10 @@ protocol AttemptMaker: class {
 
 protocol TokenMaker: class {
     func token(token: String, expires: TimeInterval, info: [String: String]) -> InvalidatableToken
+}
+
+protocol CodeMaker: class {
+    func code(code: String, info: [String: String]) -> Code
 }
 
 protocol WebControllerMaker: class {

--- a/Library/Sources/Dependecies/DependenciesImpl.swift
+++ b/Library/Sources/Dependecies/DependenciesImpl.swift
@@ -155,7 +155,9 @@ final class DependenciesImpl: Dependencies {
             tokenParser: TokenParserImpl(),
             vkAppProxy: vkAppProxy,
             webPresenter: webPresenter,
-            cookiesHolder: nil
+            cookiesHolder: nil,
+            codeParser: CodeParserImpl(),
+            codeMaker: self
         )
     }()
     
@@ -260,6 +262,10 @@ final class DependenciesImpl: Dependencies {
             expires: expires,
             info: info
         )
+    }
+    
+    func code(code: String, info: [String : String]) -> Code {
+        return CodeImpl(code: code, info: info)
     }
     
     private func urlRequestBuilder() -> UrlRequestBuilder {

--- a/Library/Sources/Presentation/Web/WebPresenter.swift
+++ b/Library/Sources/Presentation/Web/WebPresenter.swift
@@ -147,6 +147,9 @@ final class WebPresenterImpl: WebPresenter {
         if fragment.isEmpty && query.isEmpty {
             return .fail
         }
+        else if fragment.contains("code=") {
+            return .response(fragment)
+        }
         else if fragment.contains("access_token=") {
             return .response(fragment)
         }

--- a/Library/Sources/Sessions/Code/Code.swift
+++ b/Library/Sources/Sessions/Code/Code.swift
@@ -1,0 +1,48 @@
+//
+//  Code.swift
+//  SwiftyVK_macOS
+//
+//  Created by PeterSamokhin on 30.03.2020.
+//
+
+import Foundation
+
+public protocol Code: class {
+    var info: [String: String] { get }
+    
+    func get() -> String?
+}
+
+final class CodeImpl: NSObject, Code {
+    
+    private let code: String
+    let info: [String: String]
+    
+    init(
+        code: String,
+        info: [String: String]
+    ) {
+        self.code = code
+        self.info = info
+    }
+    
+    func get() -> String? {
+        return code
+    }
+    
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(code, forKey: "code")
+        aCoder.encode(info, forKey: "info")
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        guard
+            let code = aDecoder.decodeObject(forKey: "code") as? String,
+            let info = aDecoder.decodeObject(forKey: "info") as? [String: String] else {
+                return nil
+        }
+        
+        self.code = code
+        self.info = info
+    }
+}

--- a/Library/Sources/Sessions/Code/CodeParser.swift
+++ b/Library/Sources/Sessions/Code/CodeParser.swift
@@ -1,0 +1,44 @@
+//
+//  CodeParser.swift
+//  SwiftyVK_macOS
+//
+//  Created by PeterSamokhin on 30.03.2020.
+//
+
+import Foundation
+
+protocol CodeParser: class {
+    func parse(codeInfo: String) -> (code: String, info: [String: String])?
+}
+
+final class CodeParserImpl: CodeParser {
+    
+    func parse(codeInfo: String) -> (code: String, info: [String: String])? {
+        var code: String?
+        var info = [String: String]()
+        
+        let components = codeInfo.components(separatedBy: "&")
+        
+        components.forEach { component in
+            let componentPair = component.components(separatedBy: "=")
+            
+            if let key = componentPair.first, let value = componentPair.last {
+                
+                switch key {
+                case "code":
+                    code = value
+                default:
+                    break
+                }
+                
+                info[key] = value
+            }
+        }
+        
+        guard let unwrappedCode = code else {
+            return nil
+        }
+        
+        return (unwrappedCode, info)
+    }
+}

--- a/Library/SwiftyVK.xcodeproj/project.pbxproj
+++ b/Library/SwiftyVK.xcodeproj/project.pbxproj
@@ -24,6 +24,16 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1394A0302432942E000B6227 /* CodeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A02E2432942E000B6227 /* CodeParser.swift */; };
+		1394A0312432942E000B6227 /* CodeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A02E2432942E000B6227 /* CodeParser.swift */; };
+		1394A0322432942E000B6227 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A02F2432942E000B6227 /* Code.swift */; };
+		1394A0332432942E000B6227 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A02F2432942E000B6227 /* Code.swift */; };
+		1394A03524329505000B6227 /* CodeParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A03424329505000B6227 /* CodeParserTest.swift */; };
+		1394A03624329505000B6227 /* CodeParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A03424329505000B6227 /* CodeParserTest.swift */; };
+		1394A03924329549000B6227 /* CodeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A03724329549000B6227 /* CodeMock.swift */; };
+		1394A03A24329549000B6227 /* CodeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A03724329549000B6227 /* CodeMock.swift */; };
+		1394A03B24329549000B6227 /* CodeParserMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A03824329549000B6227 /* CodeParserMock.swift */; };
+		1394A03C24329549000B6227 /* CodeParserMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1394A03824329549000B6227 /* CodeParserMock.swift */; };
 		A20CDD941EF667B000271276 /* CaptchaPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20CDD931EF667B000271276 /* CaptchaPresenterTests.swift */; };
 		A20CDD961EF66AEC00271276 /* CaptchaControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20CDD951EF66AEC00271276 /* CaptchaControllerMock.swift */; };
 		A22179C81EBA3DBD006B71FD /* AttemptShedulerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A22179C71EBA3DBD006B71FD /* AttemptShedulerMock.swift */; };
@@ -589,6 +599,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1394A02E2432942E000B6227 /* CodeParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeParser.swift; sourceTree = "<group>"; };
+		1394A02F2432942E000B6227 /* Code.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
+		1394A03424329505000B6227 /* CodeParserTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeParserTest.swift; sourceTree = "<group>"; };
+		1394A03724329549000B6227 /* CodeMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeMock.swift; sourceTree = "<group>"; };
+		1394A03824329549000B6227 /* CodeParserMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeParserMock.swift; sourceTree = "<group>"; };
 		A20CDD931EF667B000271276 /* CaptchaPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptchaPresenterTests.swift; sourceTree = "<group>"; };
 		A20CDD951EF66AEC00271276 /* CaptchaControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptchaControllerMock.swift; sourceTree = "<group>"; };
 		A22179C71EBA3DBD006B71FD /* AttemptShedulerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttemptShedulerMock.swift; sourceTree = "<group>"; };
@@ -899,6 +914,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1394A02D2432942E000B6227 /* Code */ = {
+			isa = PBXGroup;
+			children = (
+				1394A02E2432942E000B6227 /* CodeParser.swift */,
+				1394A02F2432942E000B6227 /* Code.swift */,
+			);
+			path = Code;
+			sourceTree = "<group>";
+		};
 		A23708C51EA52F9C00103212 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -908,6 +932,7 @@
 				A2433A421EA5331A0058BB6D /* Doubles */,
 				A25A19D21EE438FB00CF13AF /* AuthorizatorTests.swift */,
 				A25A19CF1EE4233D00CF13AF /* TokenParserTests.swift */,
+				1394A03424329505000B6227 /* CodeParserTest.swift */,
 				A23708C61EA5309700103212 /* TaskShedulerTests.swift */,
 				A2433A451EA542100058BB6D /* AttemptShedulerTests.swift */,
 				A2B40DFC1EA693B700106AE3 /* UrlRequestBuilderTests.swift */,
@@ -955,6 +980,8 @@
 		A2433A421EA5331A0058BB6D /* Doubles */ = {
 			isa = PBXGroup;
 			children = (
+				1394A03724329549000B6227 /* CodeMock.swift */,
+				1394A03824329549000B6227 /* CodeParserMock.swift */,
 				A2433A431EA533500058BB6D /* TaskMock.swift */,
 				A2433A471EA542620058BB6D /* AttemptMock.swift */,
 				A24DDAEB1EB73C9E002EA273 /* QueryBuilderMock.swift */,
@@ -1291,6 +1318,7 @@
 		D4BBFDDE1F9297A9009615E7 /* Sessions */ = {
 			isa = PBXGroup;
 			children = (
+				1394A02D2432942E000B6227 /* Code */,
 				D46FB3D81F929AB7000CEAEB /* Token */,
 				D46FB3DB1F929C7A000CEAEB /* Management */,
 				D4BBFDE01F9297A9009615E7 /* Session.swift */,
@@ -1841,6 +1869,7 @@
 				A23E692C1EDAEC5800AA3B3B /* VKAppProxyTests.swift in Sources */,
 				D484C9411F4B3E8300C9651C /* VKURLSessionTaskMock.swift in Sources */,
 				A2B805581EDDB313004DA7EB /* WebPresenterTests.swift in Sources */,
+				1394A03924329549000B6227 /* CodeMock.swift in Sources */,
 				D4B850381FB0DB8700EF02F0 /* ShareWorkerTests.swift in Sources */,
 				A22179CA1EBA4059006B71FD /* SessionTests.swift in Sources */,
 				A2E5C5D91ECCAD4800652262 /* SessionsHolderMock.swift in Sources */,
@@ -1878,6 +1907,7 @@
 				D44AD0D71FB208600053AD59 /* Media+TestExtensions.swift in Sources */,
 				A20CDD941EF667B000271276 /* CaptchaPresenterTests.swift in Sources */,
 				D44EC0161F55D50600F8BB4A /* VKNotificationCenterMock.swift in Sources */,
+				1394A03524329505000B6227 /* CodeParserTest.swift in Sources */,
 				D41B3D001F9FB48C00177075 /* ShareControllerMock.swift in Sources */,
 				D4F49D3F1F2DF53F0037B875 /* ApiErrorTests.swift in Sources */,
 				A2B805561EDDB01C004DA7EB /* WebControllerMock.swift in Sources */,
@@ -1902,6 +1932,7 @@
 				D48F789A1F9FA51C0092931E /* SharePresenterMock.swift in Sources */,
 				D4321D8D1F5F0A31001AFE9F /* OneVariationsMethodTests.swift in Sources */,
 				D4B850331FB0A78C00EF02F0 /* SynchronouslyTaskTests.swift in Sources */,
+				1394A03B24329549000B6227 /* CodeParserMock.swift in Sources */,
 				A24DDAF01EB73CB6002EA273 /* BodyBuilderMock.swift in Sources */,
 				D4321D931F5F0D7C001AFE9F /* ThreeVariationsMethodTests.swift in Sources */,
 				D41ADB021F4DFEE000E10D41 /* ResourcesTests.swift in Sources */,
@@ -1965,6 +1996,7 @@
 				D4BBFF911F929892009615E7 /* Video.swift in Sources */,
 				D4BBFF741F929892009615E7 /* Messages.swift in Sources */,
 				D4BBFFCB1F929893009615E7 /* SessionsHolder.swift in Sources */,
+				1394A0332432942E000B6227 /* Code.swift in Sources */,
 				D4BBFFA91F929893009615E7 /* CookiesStorage.swift in Sources */,
 				D4BBFFA31F929893009615E7 /* GCD+Extensions.swift in Sources */,
 				D4BBFFBD1F929893009615E7 /* CookiesHolder.swift in Sources */,
@@ -1993,6 +2025,7 @@
 				D46FB4321F929E4E000CEAEB /* CaptchaController_iOS.swift in Sources */,
 				D4BBFFA21F929893009615E7 /* VKFileManager.swift in Sources */,
 				D46FB42B1F929E3C000CEAEB /* WebController_iOS.swift in Sources */,
+				1394A0312432942E000B6227 /* CodeParser.swift in Sources */,
 				D4DC124C1FAB542B00D977D8 /* SharePreferencesCell_iOS.swift in Sources */,
 				D423E0491FA640D90083C8FB /* ShareImageCollectionView_iOS.swift in Sources */,
 				D4BBFFB51F929893009615E7 /* Response.swift in Sources */,
@@ -2079,10 +2112,12 @@
 				D4BBFF061F929891009615E7 /* Token.swift in Sources */,
 				D4BBFEE21F929891009615E7 /* DependenciesImpl.swift in Sources */,
 				D4142BDD1FBDE875009CB511 /* ShareImageCollectionView_macOS.swift in Sources */,
+				1394A0302432942E000B6227 /* CodeParser.swift in Sources */,
 				D4DADE071F9F9AE9004F159E /* ShareContext.swift in Sources */,
 				D4BBFEC01F929891009615E7 /* Friends.swift in Sources */,
 				D46FB4261F929E3C000CEAEB /* WebViewWrapper_macOS.swift in Sources */,
 				D4BBFEC61F929891009615E7 /* Market.swift in Sources */,
+				1394A0322432942E000B6227 /* Code.swift in Sources */,
 				D4BBFEC81F929891009615E7 /* Wall.swift in Sources */,
 				D4BBFEF01F929891009615E7 /* RequestConfig.swift in Sources */,
 				D4BBFEB41F929891009615E7 /* Places.swift in Sources */,
@@ -2222,6 +2257,7 @@
 				D46FB4011F929DBC000CEAEB /* ApiMethodTests.swift in Sources */,
 				D46FB3FA1F929DBC000CEAEB /* CaptchaPresenterTests.swift in Sources */,
 				D46FB3F81F929DBC000CEAEB /* WebPresenterTests.swift in Sources */,
+				1394A03A24329549000B6227 /* CodeMock.swift in Sources */,
 				D477065D1FE4274800D72930 /* RequestTests.swift in Sources */,
 				D46FB4091F929DBC000CEAEB /* ThreeVariationsMethodTests.swift in Sources */,
 				D46FB4051F929DBC000CEAEB /* TaskTests.swift in Sources */,
@@ -2246,6 +2282,7 @@
 				D44AD0D81FB208600053AD59 /* Media+TestExtensions.swift in Sources */,
 				D46FB40E1F929DBC000CEAEB /* LongPollEventTests.swift in Sources */,
 				D46FB3F31F929DBC000CEAEB /* SessionTests.swift in Sources */,
+				1394A03C24329549000B6227 /* CodeParserMock.swift in Sources */,
 				D41B3D011F9FB48C00177075 /* ShareControllerMock.swift in Sources */,
 				D46FB4071F929DBC000CEAEB /* OneVariationsMethodTests.swift in Sources */,
 				D46FB4491F929EE6000CEAEB /* SessionStorageMock.swift in Sources */,
@@ -2267,6 +2304,7 @@
 				D46FB3F61F929DBC000CEAEB /* TokenStorageTests.swift in Sources */,
 				D46FB41E1F929DCB000CEAEB /* RequestType+TestExtensions.swift in Sources */,
 				D48F789B1F9FA51C0092931E /* SharePresenterMock.swift in Sources */,
+				1394A03624329505000B6227 /* CodeParserTest.swift in Sources */,
 				D46FB3FD1F929DBC000CEAEB /* ResponseTests.swift in Sources */,
 				D4B850341FB0A78C00EF02F0 /* SynchronouslyTaskTests.swift in Sources */,
 				D46FB43B1F929EE6000CEAEB /* SessionMock.swift in Sources */,

--- a/Library/Tests/CodeParserTest.swift
+++ b/Library/Tests/CodeParserTest.swift
@@ -1,0 +1,33 @@
+//
+//  CodeParserTest.swift
+//  SwiftyVK
+//
+//  Created by PeterSamokhin on 30.03.2020.
+//
+
+import XCTest
+@testable import SwiftyVK
+
+final class CodeParserTests: XCTestCase {
+    
+    func test_parseValidToken() {
+        // Given
+        let parser = CodeParserImpl()
+        let info = "code=1234567890&info=testInfo"
+        // When
+        let result = parser.parse(codeInfo: info)
+        // Then
+        XCTAssertEqual(result?.code, "1234567890")
+        XCTAssertEqual(result?.info ?? [:], ["info": "testInfo", "code": "1234567890"])
+    }
+    
+    func test_parseWithoutToken() {
+        // Given
+        let parser = CodeParserImpl()
+        let info = "info=testInfo"
+        // When
+        let result = parser.parse(codeInfo: info)
+        // Then
+        XCTAssertNil(result)
+    }
+}

--- a/Library/Tests/DependenciesTests.swift
+++ b/Library/Tests/DependenciesTests.swift
@@ -111,6 +111,15 @@ final class DependenciesTests: XCTestCase {
         XCTAssertTrue(type(of: object) == TokenImpl.self)
     }
     
+    func test_makeCode_typeIsCodeImpl() {
+        // Given
+        let context = makeContext()
+        // When
+        let object = context.factory.code(code: "", info: [:])
+        // Then
+        XCTAssertTrue(type(of: object) == CodeImpl.self)
+    }
+    
     func test_makeSharePresenter_typeIsSharePresenterImpl() {
         // Given
         let context = makeContext()

--- a/Library/Tests/Doubles/AuthorizatorMock.swift
+++ b/Library/Tests/Doubles/AuthorizatorMock.swift
@@ -19,6 +19,19 @@ final class AuthorizatorMock: Authorizator {
         return result
     }
     
+    var onAuthorizeCode: ((String, SessionConfig, Bool) throws -> Code)?
+    
+    func authorizeCode(sessionId: String, config: SessionConfig, revoke: Bool) throws -> Code {
+        authorizeCallCount += 1
+        
+        guard let result = try onAuthorizeCode?(sessionId, config, revoke) else {
+            XCTFail("onAuthorize not defined")
+            return CodeMock()
+        }
+
+        return result
+    }
+    
     var authorizeWithRawTokenCallCount = 0
     
     var onRawAuthorize: ((String, String, TimeInterval) -> InvalidatableToken)?

--- a/Library/Tests/Doubles/CodeMock.swift
+++ b/Library/Tests/Doubles/CodeMock.swift
@@ -1,0 +1,30 @@
+//
+//  CodeMock.swift
+//  SwiftyVK
+//
+//  Created by PeterSamokhin on 30.03.2020.
+//
+
+@testable import SwiftyVK
+
+final class CodeMock: NSObject, Code {
+    
+    var code: String?
+    let info: [String: String] = [:]
+    
+    init(code: String = "testToken") {
+        self.code = code
+    }
+    
+    init?(coder aDecoder: NSCoder) {
+        code = aDecoder.decodeObject(forKey: "code") as? String ?? ""
+    }
+    
+    func get() -> String? {
+        return code
+    }
+    
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(code, forKey: "code")
+    }
+}

--- a/Library/Tests/Doubles/CodeParserMock.swift
+++ b/Library/Tests/Doubles/CodeParserMock.swift
@@ -1,0 +1,17 @@
+//
+//  CodeParserMock.swift
+//  SwiftyVK_macOS
+//
+//  Created by PeterSamokhin on 30.03.2020.
+//
+
+@testable import SwiftyVK
+
+final class CodeParserMock: CodeParser {
+    
+    var onParse: ((String) -> (code: String, info: [String : String])?)?
+    
+    func parse(codeInfo: String) -> (code: String, info: [String : String])? {
+        return onParse?(codeInfo)
+    }
+}

--- a/Library/Tests/Doubles/DependencyFactoryMock.swift
+++ b/Library/Tests/Doubles/DependencyFactoryMock.swift
@@ -65,6 +65,20 @@ final class TokenMakerMock: TokenMaker {
     }
 }
 
+final class CodeMakerMock: CodeMaker {
+    
+    var onMake: ((String, [String: String]) -> Code)?
+    
+    func code(code: String, info: [String: String]) -> Code {
+        guard let result = onMake?(code, info) else {
+            XCTFail("onMake not defined")
+            return CodeMock()
+        }
+        
+        return result
+    }
+}
+
 final class WebControllerMakerMock: WebControllerMaker {
     
     var onMake: (() -> WebController)?

--- a/Library/Tests/Doubles/SessionMock.swift
+++ b/Library/Tests/Doubles/SessionMock.swift
@@ -25,6 +25,10 @@ final class SessionMock: Session, TaskSession, DestroyableSession, ApiErrorExecu
         
     }
     
+    func logInCode(onSuccess: @escaping ([String : String]) -> (), onError: @escaping RequestCallbacks.Error) {
+        
+    }
+    
     var onInvalidate: (() -> ())?
     
     func invalidate() {

--- a/Library/Tests/Doubles/SwiftyVKDelegateMock.swift
+++ b/Library/Tests/Doubles/SwiftyVKDelegateMock.swift
@@ -6,6 +6,7 @@ final class SwiftyVKDelegateMock: SwiftyVKDelegate {
     var onVKTokenCreated: ((String, [String : String]) -> ())?
     var onVKTokenUpdated: ((String, [String : String]) -> ())?
     var onVKTokenRemoved: ((String) -> ())?
+    var onVKCodeCreated: ((String, [String : String]) -> ())?
     
     func vkNeedToPresent(viewController: VKViewController) {
         vkNeedToPresent?(viewController)
@@ -25,5 +26,9 @@ final class SwiftyVKDelegateMock: SwiftyVKDelegate {
     
     func vkTokenRemoved(for sessionId: String) {
         onVKTokenRemoved?(sessionId)
+    }
+    
+    func vkCodeCreated(for sessionId: String, info: [String : String]) {
+        onVKCodeCreated?(sessionId, info)
     }
 }

--- a/Library/Tests/WebPresenterTests.swift
+++ b/Library/Tests/WebPresenterTests.swift
@@ -39,6 +39,27 @@ final class WebPresenterTests: XCTestCase {
         XCTAssertEqual(result, "access_token=test")
     }
     
+    func test_load_returnCode_whenCodeRecieved() {
+        // Given
+        let context = makeContext()
+        
+        context.webControllerMaker.onMake = {
+            let controller = WebControllerMock()
+
+            controller.onLoad = { url, onResult in
+                onResult(.response(url))
+            }
+            
+            return controller
+        }
+        // When
+        let result = try? context.presenter.presentWith(
+            urlRequest: urlRequest(string: "http://vk.com#code=test")!
+        )
+        // Then
+        XCTAssertEqual(result, "code=test")
+    }
+    
     func test_load_throwWrongAuthUrl_whenUrlIsNil() {
         // Given
         let context = makeContext()

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
@@ -6,12 +7,12 @@ let package = Package(
         .library(
             name: "SwiftyVK",
             targets: ["SwiftyVK_macOS", "SwiftyVK_iOS"]
-        ),
-        targets: [
+        )
+    ],
+    targets: [
         .target(name: "SwiftyVK_macOS", dependencies: ["SwiftyVK_resources_macOS"]),
         .target(name: "SwiftyVK_iOS", dependencies: ["SwiftyVK_resources_iOS"]),
         .testTarget(name: "SwiftyVK_tests_macOS", dependencies: ["SwiftyVK_macOS"]),
         .testTarget(name: "SwiftyVK_tests_iOS", dependencies: ["SwiftyVK_iOS"]),
-        ]
     ]
 )


### PR DESCRIPTION
Added the ability to receive code for the server-side auth.
Code Flow is available only through the WebView due to the hardcoded `response_type` in the VK iOS app.